### PR TITLE
Fix missing docx if-block and update PDF merge method

### DIFF
--- a/document_processor/src/design_editor_docx.py
+++ b/document_processor/src/design_editor_docx.py
@@ -205,7 +205,8 @@ def add_simple_page_numbers_docx(doc_path: str, output_path: str):
             if not p.text and not p.runs:
                  # Add a default run if paragraph is completely empty to ensure footer is visible
                  # This might not be necessary if the field itself makes the paragraph non-empty
-                 # p.add_run(" ") # Placeholder if needed, but field should suffice
+                 # p.add_run(" ")  # Placeholder if needed, but field should suffice
+                 pass
 
         doc.save(output_path)
         print(f"DOCX simple page numbers added and saved to {output_path}")

--- a/document_processor/src/pdf_layout_editor.py
+++ b/document_processor/src/pdf_layout_editor.py
@@ -1,4 +1,4 @@
-from PyPDF2 import PdfReader, PdfWriter
+from PyPDF2 import PdfReader, PdfWriter, Transformation
 from PyPDF2.generic import RectangleObject # For page size
 
 # Standard page sizes in points (1 inch = 72 points)
@@ -110,12 +110,13 @@ def resize_and_margin_pdf_content(pdf_path: str, output_path: str,
             # ty = m_bottom_pt + (content_area_height - scaled_content_height) / 2
 
 
-            new_page.merge_scaled_translated_page(
-                original_page,
-                scale=scale_factor,
-                tx=tx,
-                ty=ty
-            )
+            transformation = Transformation().scale(scale_factor).translate(tx, ty)
+            try:
+                new_page.merge_transformed_page(original_page, transformation)
+            except AttributeError:
+                # Fallback for older PyPDF2 versions
+                original_page.add_transformation(transformation)
+                new_page.merge_page(original_page)
 
         with open(output_path, "wb") as f_out:
             writer.write(f_out)

--- a/scripts/generate_large_test_files.py
+++ b/scripts/generate_large_test_files.py
@@ -15,8 +15,8 @@ TARGET_CHARS = 300000
 # A sample Japanese paragraph (approx 100 chars, including punctuation)
 # "吾輩は猫である。名前はまだ無い。どこで生れたかとんと見当がつかぬ。何でも薄暗いじめじめした所でニャーニャー泣いていた事だけは記憶している。" (Natsume Soseki)
 # This is 71 characters.
-# sample_paragraph = "これは大規模ファイル処理の検証と改善のために使用される、約30万文字の日本語テストドキュメントです。この文章は繰り返し生成され、指定された文字数に達するまで続きます。
-" # approx 100 chars
+# sample_paragraph = "これは大規模ファイル処理の検証と改善のために使用される、約30万文字の日本語テストドキュメントです。この文章は繰り返し生成され、指定された文字数に達するまで続きます。"
+# # approx 100 chars
 sample_paragraph = "吾輩は猫である。名前はまだ無い。どこで生れたかとんと見当がつかぬ。何でも薄暗いじめじめした所でニャーニャー泣いていた事だけは記憶している。吾輩はここで始めて人間というものを見た。\n" # approx 100 chars
 
 generated_text = ""


### PR DESCRIPTION
## Summary
- fix empty `if` block in DOCX page-numbering utility
- use proper PyPDF2 transformation API and fallback
- comment out stray line in large test file generator

## Testing
- `python -m py_compile $(git ls-files '*.py')`